### PR TITLE
Requirements (first cut)

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -1,6 +1,7 @@
 - title: Getting Started
   docs:
   - home
+  - requirements
   - quickstart
 
 - title: Meta

--- a/_docs/quickstart.md
+++ b/_docs/quickstart.md
@@ -13,6 +13,10 @@ A quick introduction to Flux and flux-core.
 
 ### Building the code
 
+Ensure the latest list of requirements are installed.
+The currrent list of build requirements are detailed
+[here](../requirements).
+
 Clone current flux-core master:
 
 {% highlight bash %}

--- a/_docs/requirements.md
+++ b/_docs/requirements.md
@@ -1,0 +1,84 @@
+---
+layout: docs
+title: "Build prerequesites"
+permalink: /docs/requirements/
+---
+
+This page is intended to list build requirements for
+base Flux framework projects, notably [flux-core](https://github.com/flux-framework/flux-core),
+which is the foundation for most other framework projects.
+
+The major requirements are listed in the sections below. Requirements are also kept
+up to date in a Travis-CI helper script in the flux-core source,
+[`travis-dep-builder.sh`](https://github.com/flux-framework/flux-core/blob/master/src/test/travis-dep-builder.sh),
+which can either be run by hand to download requirements, or viewed to determine latest required versions
+and packages. `travis-dep-builder.sh` requires `pip` and `luarocks` to fetch python and Lua dependencies:
+
+{% highlight bash %}
+~/flux-core.git $ src/test/travis-dep-builder.sh
+...
+~/flux-core.git $ $(src/test/travis-dep-builder.sh --printenv)
+~/flux-core.git $ ./autogen.sh && ./configure 
+{% endhighlight %}
+
+---
+
+* toc
+{:toc}
+
+### ZeroMQ
+
+Flux core messaging is built on the excellent [zeromq](http://zeromq.org/)
+messaging library. Flux currently requires a relatively recent version of zeromq,
+built with libsodium support, as well as the [czmq](https://github.com/zeromq/czmq)
+bindings for C:
+
+| Requirement | version  |   Notes                  |
+|:------------|:---------|:------------------------:|
+| `libsoduim` | `>1.0.1` |                          |
+| `zeromq`    | `>4.0.4` | built `--with-libsodium` |
+| `czmq`      | `=3.0.2` |                          |
+|=============|==========|==========================|
+
+### JSON
+
+Flux makes heavy use of JSON encoding for messages. The code
+currently requires [json-c](https://github.com/json-c/json-c)
+v0.11 or greater.
+
+### MUNGE
+
+* [libmunge](https://github/dun/munge) v0.5.11 or greater
+
+### hwloc
+
+ * [hwloc](https://www.open-mpi.org/projects/hwloc/) v1.11 or greater.
+
+### Lua
+ 
+Flux makes use of Lua scripts and bindings for some functionality.
+Lua 5.1 is required for now. However, support for v5.2 and v5.3
+is planned in the near future.
+
+Lua module requirements include:
+ 
+ * luaposix
+
+Internal versions of `lua-hostlist` and `lua-affinity` are supplied
+with flux-core.
+
+### Python
+
+Generation of flux-core bindings for python requires the following
+version of Python and support libs
+
+ | Requirement | version  | Notes                    |
+ |:------------|:---------|:------------------------:|
+ | `python`    | `>=2.7`  |                          |
+ | `cffi`      | `>=1.0`  |                          |
+ | `pycparser` | `>=2.2`  |                          |
+ | `ply`       | `>=3.6`  |                          |
+
+### Asciidoc
+
+Manual pages are written in asciidoc. For man page generation `asciidoc` is required.

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -10,7 +10,7 @@ layout: default
       <div class="unit four-fifths">
         <article>
           <div class="improve right hide-on-mobiles">
-            <a href="https://github.com/flux-framework/flux-framework.github.io/git/master/site/{{ page.path }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
+            <a href="https://github.com/flux-framework/flux-framework.github.io/edit/master/{{ page.path }}"><i class="fa fa-pencil"></i> &nbsp;Improve this page</a>
           </div>
           <h1>{{ page.title }}</h1>
           {{ content }}


### PR DESCRIPTION
This branch fixes the "improve this page" link (I think). And adds a first cut Build prereqs under docs, referenced from Quickstart.

I'm not too happy with the form of the requirements page, but it is a start for now. May be better for someone to simplify or take another approach. (Also @trws will want to add his link for spack at some point)