### PR TITLE
Cap updates

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -28,5 +28,9 @@ Current projects include:
    scheduling plugins that provide specific scheduling behavior.
  
  * [capacitor](https://github.com/flux-framework/capacitor) - implements a
-   bulk load utility on top of flux-core.
-
+   bulk execution manager using flux-core.  Capacitor provides functionality
+   like that of job arrays or tools like
+   [CRAM](https://github.com/scalability-llnl/cram), except with the full
+   capabilities of flux and its job scheduling facilities like flux-sched.  If
+   you need to run and monitor thousands of jobs in an allocation, and don't
+   want an email from your sysadmins, consider flux and capacitor.

--- a/_docs/quickstart.md
+++ b/_docs/quickstart.md
@@ -4,14 +4,29 @@ title: "Quickstart"
 permalink: /docs/quickstart/
 ---
 
-***
+---
+
 A quick introduction to Flux and flux-core.
 
 * Generate TOC:
 {:toc}
-***
+
+---
 
 ### Building the code
+
+#### Spack: Recommended for curious users
+
+Flux maintains an up-to-date package in the spack develop branch, which builds
+all dependencies and flux itself from the current head of the master branch.
+If you're already using [spack](https://github.com/scalability-llnl/spack),
+just run the following to install flux and all necessary dependencies:
+
+{% highlight bash %}
+$ spack install flux
+{% endhighlight %}
+
+#### Manual: Recommended for developers and contributers
 
 Ensure the latest list of requirements are installed.
 The currrent list of build requirements are detailed

--- a/_docs/requirements.md
+++ b/_docs/requirements.md
@@ -21,6 +21,10 @@ and packages. `travis-dep-builder.sh` requires `pip` and `luarocks` to fetch pyt
 ~/flux-core.git $ ./autogen.sh && ./configure 
 {% endhighlight %}
 
+Alternately [spack](https://github.com/scalability-llnl/spack) can be used to
+build all flux dependencies with either `spack install flux` or `spack diy
+flux@master` from inside a clone of the flux repository.
+
 ---
 
 * toc

--- a/_includes/docs_ul.html
+++ b/_includes/docs_ul.html
@@ -11,7 +11,7 @@
   {% endif %}
 
   {% assign p = site.docs | where:"url",item_url | first %}
-  <li class="{{ c }}"><a href="{{ site.url }}{{ p.url }}">{{ p.title }}</a></li>
+  <li class="{{ c }}"><a href="{{ p.url }}">{{ p.title }}</a></li>
 
 {% endfor %}
 </ul>


### PR DESCRIPTION
Adding a bit more capacitor material and the spack options.  One of the commits also makes local development a bit easier, it just makes sure all of the sidebar links are generated as relative to current site root rather than site URL.