### PR TITLE
Add news entry for flux-core 0.4.0

### DIFF
--- a/_posts/2016-08-11-flux-core-0.4.0-released.md
+++ b/_posts/2016-08-11-flux-core-0.4.0-released.md
@@ -1,0 +1,80 @@
+---
+layout: news_item
+title: "flux-core v0.4.0 Released"
+date: "2016-08-11 19:09:27 -0700"
+author: "grondo"
+categories: release
+version: 0.4.0
+---
+
+# flux-core v0.4.0 Released
+
+<div class="note warning">
+This is an alpha release of flux-core and is not intended for production use.
+</div>
+
+Download from GitHub [here](https://github.com/flux-framework/flux-core/releases/tag/v0.4.0)
+
+## Release Notes
+
+#### Scalability improvements
+
+* don't store broken-down hwloc topology in the KVS ([#716](https://github.com/flux-framework/flux-core/issues/716))
+
+* route rank-addressed requests via TBON ([#689](https://github.com/flux-framework/flux-core/issues/689))
+
+* streamline matchtag handling ([#687](https://github.com/flux-framework/flux-core/issues/687))
+
+* keep active jobs in a separate KVS namespace from "archived" jobs ([#609](https://github.com/flux-framework/flux-core/issues/609))
+
+#### New features
+
+* implement PMI-1 simple server in wrexecd ([#706](https://github.com/flux-framework/flux-core/issues/706))
+
+* add skeletal PMI-2 library (based on PMI-1) ([#747](https://github.com/flux-framework/flux-core/issues/747))
+
+* make libflux-optparse.so available externally ([#702](https://github.com/flux-framework/flux-core/issues/702))
+
+* asynchronous KVS fence and rewritten fence path in KVS module ([#707](https://github.com/flux-framework/flux-core/issues/707), [#729](https://github.com/flux-framework/flux-core/issues/729))
+
+* `flux-cron`, a cron/at-like service ([#626](https://github.com/flux-framework/flux-core/issues/626))
+
+* `flux-proxy` and `ssh://` connector ([#645](https://github.com/flux-framework/flux-core/issues/645))
+
+#### Other changes
+
+* Use RFC 5424 log format for internal logging, not ad hoc JSON ([#691](https://github.com/flux-framework/flux-core/issues/691))
+
+* Add wreck lua.d MPI personalities ([#669](https://github.com/flux-framework/flux-core/issues/669), [#743](https://github.com/flux-framework/flux-core/issues/743), [#747](https://github.com/flux-framework/flux-core/issues/747))
+
+* Improved command line for launching flux from slurm/flux ([#658](https://github.com/flux-framework/flux-core/issues/658))
+
+* Assorted code cleanup.
+
+* Automatic github release upload on tags ([#744](https://github.com/flux-framework/flux-core/issues/744))
+
+#### Deprecations
+
+* Sophia content backing store module ([#727](https://github.com/flux-framework/flux-core/issues/727))
+
+* mrpc KVS based muti-RPC interface ([#689](https://github.com/flux-framework/flux-core/issues/689))
+
+* ZPL config file ([#674](https://github.com/flux-framework/flux-core/issues/674))
+
+* Ring overlay network ([#689](https://github.com/flux-framework/flux-core/issues/689))
+
+#### Testing
+
+* Print backtraces for any core files generated in travis-ci ([#703](https://github.com/flux-framework/flux-core/issues/703))
+
+* Add cppcheck target to travis-ci ([#701](https://github.com/flux-framework/flux-core/issues/701))
+
+* configure --enable-sanitizer for AddressSanitizer, ThreadSanitizer ([#694](https://github.com/flux-framework/flux-core/issues/694))
+
+* caliper based profiling ([#741](https://github.com/flux-framework/flux-core/issues/741))
+
+* coverage uploaded to CodeCof ([#751](https://github.com/flux-framework/flux-core/issues/751))
+
+* improved test coverage
+
+


### PR DESCRIPTION
Add GitHub pages news entry for release 0.4.0.

Actually generated from an experimental script run within a git checkout of the tag, which copies Release Notes directly from `NEWS.md` with common front matter, and replaces all `#[0-9]+` with a link to the issue.
```sh
URL="https://github.com/flux-framework/flux-core/issues/"
TAG=$(git describe)
VERSION=$(git describe | sed 's/^v//')
AUTHOR="flux-framework"
COMMIT=$(git rev-parse $TAG)
DATE=$( git cat-file -p $COMMIT \
      | gawk '/^tagger/{print strftime ("%F %H:%M:%S %z", $(NF-1))}')

# Front matter
cat <<EOF
---
layout: news_item
title: "flux-core v$VERSION Released"
date: "$DATE"
author: "$AUTHOR"
categories: release
version: $VERSION
---

# flux-core v$VERSION Released

<div class="note warning">
This is an alpha release of flux-core and is not intended for production use.
</div>

Download from GitHub [here](https://github.com/flux-framework/flux-core/releases/tag/$TAG)

## Release Notes
EOF

# Get top list of Release Notes for a single version
#   replace Issue #'s with links
#
awk '/^flux-core version/{n++;getline;getline}; n<=1;' NEWS.md \
    | sed "s|\#\([0-9][0-9]*\)|[#\1](${URL}\1)|g"

```