### PR TITLE
highlighter:  change 'pygments' to 'rouge'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: kramdown
-highlighter: pygments
+highlighter: rouge
 permalink: /news/:year/:month/:day/:title/
 excerpt_separator: ""
 

--- a/css/screen.scss
+++ b/css/screen.scss
@@ -4,6 +4,6 @@
 @import "mixins";
 @import "normalize";
 @import "gridism";
-@import "pygments";
+@import "rouge";
 @import "font-awesome";
 @import "style";


### PR DESCRIPTION
Address this warning from github:
The page build completed successfully, but returned the following warning:

You are attempting to use the 'pygments' highlighter, which is
currently unsupported on GitHub Pages. Your site will use 'rouge' for
highlighting instead. To suppress this warning, change the
'highlighter' value to 'rouge' in your '_config.yml' and ensure the
'pygments' key is unset. For more information, see
https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.