### PR TITLE
Add NEWS post for flux-core v0.7.0

### DIFF
--- a/_posts/2017-04-01-flux-core-0.7.0-released.md
+++ b/_posts/2017-04-01-flux-core-0.7.0-released.md
@@ -1,0 +1,71 @@
+---
+layout: news_item
+title: "flux-core v0.7.0 Released"
+date: "2017-03-31 10:17:42 -0700"
+author: "flux-framework"
+categories: release
+version: 0.7.0
+---
+
+# flux-core v0.7.0 Released
+
+<div class="note warning">
+This is an alpha release of flux-core and is not intended for production use.
+</div>
+
+Download from GitHub [here](https://github.com/flux-framework/flux-core/releases/tag/v0.7.0)
+
+## Release Notes
+
+#### Fixes
+
+ * Improve reliability of module unloading ([#1017](https://github.com/flux-framework/flux-core/issues/1017))
+ * Update autotools for `make dist` to support newer arches ([#1016](https://github.com/flux-framework/flux-core/issues/1016))
+ * Fix corner cases in resource-hwloc module ([#1012](https://github.com/flux-framework/flux-core/issues/1012))
+ * Ensure destructors are called during broker shutdown ([#1005](https://github.com/flux-framework/flux-core/issues/1005))
+ * `flux-logger(1)` and `flux_log(3)` can return error ([#1000](https://github.com/flux-framework/flux-core/issues/1000))
+ * Fix balancing of Caliper hooks in RPC calls ([#991](https://github.com/flux-framework/flux-core/issues/991))
+ * Fix missed errors in subscribe/unsubscribe on local connector ([#994](https://github.com/flux-framework/flux-core/issues/994))
+ * sanitize log entries before they enter circular buffer ([#959](https://github.com/flux-framework/flux-core/issues/959))
+ * Do not send wreck.state.complete event before job archival ([#955](https://github.com/flux-framework/flux-core/issues/955)) 
+ * Update embedded libev to 4.24 ([#944](https://github.com/flux-framework/flux-core/issues/944))
+ * Propagate argument quoting properly in `flux-start` and `flux-broker` ([#931](https://github.com/flux-framework/flux-core/issues/931))
+ * Fixes and improvements in liboptparse ([#922](https://github.com/flux-framework/flux-core/issues/922), [#927](https://github.com/flux-framework/flux-core/issues/927), [#929](https://github.com/flux-framework/flux-core/issues/929))
+ * Tighten up PMI implementation for OpenMPI ([#926](https://github.com/flux-framework/flux-core/issues/926))
+
+#### New Features
+
+ * Allow user other than instance owner to connect to an instance ([#980](https://github.com/flux-framework/flux-core/issues/980))
+ * Systemd support, default run directory and URI for system instance
+   ([#992](https://github.com/flux-framework/flux-core/issues/992), [#995](https://github.com/flux-framework/flux-core/issues/995))
+ * New `--bootstrap` option to `flux-start` ([#990](https://github.com/flux-framework/flux-core/issues/990))
+ * New `KVS_NO_MERGE` flag in kvs commit and fence operations ([#982](https://github.com/flux-framework/flux-core/issues/982))
+ * Add `broker.pid` to broker attributes ([#954](https://github.com/flux-framework/flux-core/issues/954))
+ * `flux start` only execs broker if `--size` is not specified ([#951](https://github.com/flux-framework/flux-core/issues/951))
+ * Add pkg-config package for Flux PMI ([#921](https://github.com/flux-framework/flux-core/issues/921))
+
+#### Cleanup
+
+ * Remove live module ([#1003](https://github.com/flux-framework/flux-core/issues/1003))
+ * Remove flux-up and flux-topo ([#960](https://github.com/flux-framework/flux-core/issues/960))
+ * Transition away from deprecated czmq classes ([#1013](https://github.com/flux-framework/flux-core/issues/1013))
+ * Re-architect and improve many internal and cmd rpc functions ([#1002](https://github.com/flux-framework/flux-core/issues/1002), [#1009](https://github.com/flux-framework/flux-core/issues/1009))
+ * Other major and minor cleanup ([#919](https://github.com/flux-framework/flux-core/issues/919), [#928](https://github.com/flux-framework/flux-core/issues/928), [#941](https://github.com/flux-framework/flux-core/issues/941), [#940](https://github.com/flux-framework/flux-core/issues/940), [#942](https://github.com/flux-framework/flux-core/issues/942), [#954](https://github.com/flux-framework/flux-core/issues/954), [#969](https://github.com/flux-framework/flux-core/issues/969),
+    [#976](https://github.com/flux-framework/flux-core/issues/976), [#981](https://github.com/flux-framework/flux-core/issues/981), [#978](https://github.com/flux-framework/flux-core/issues/978), [#986](https://github.com/flux-framework/flux-core/issues/986), [#990](https://github.com/flux-framework/flux-core/issues/990), [#1001](https://github.com/flux-framework/flux-core/issues/1001), [#1008](https://github.com/flux-framework/flux-core/issues/1008))
+ * Remove `cmb.` prefix from broker services ([#947](https://github.com/flux-framework/flux-core/issues/947))
+
+#### Testing
+
+ * Expand and improve unit and system tests for greater code coverage
+   ([#937](https://github.com/flux-framework/flux-core/issues/937), [#942](https://github.com/flux-framework/flux-core/issues/942), [#979](https://github.com/flux-framework/flux-core/issues/979), [#985](https://github.com/flux-framework/flux-core/issues/985), [#991](https://github.com/flux-framework/flux-core/issues/991), [#1004](https://github.com/flux-framework/flux-core/issues/1004), [#1011](https://github.com/flux-framework/flux-core/issues/1011), [#1013](https://github.com/flux-framework/flux-core/issues/1013), [#1014](https://github.com/flux-framework/flux-core/issues/1014))
+ * Fix documentation spellcheck ([#1015](https://github.com/flux-framework/flux-core/issues/1015))
+ * Add dependency on "all" to top-level `make check` ([#970](https://github.com/flux-framework/flux-core/issues/970))
+ * Add flake8/pylint checks ([#816](https://github.com/flux-framework/flux-core/issues/816))
+
+#### Documentation
+
+ * Improve flux_reactor_create documentation ([#970](https://github.com/flux-framework/flux-core/issues/970))
+ * Update flux_msg_cmp(3) and flux_recv(3) to match flux_match changes ([#946](https://github.com/flux-framework/flux-core/issues/946))
+ * Update flux-submit(1) and flux-wreckrun(1) manpages ([#945](https://github.com/flux-framework/flux-core/issues/945))
+
+


### PR DESCRIPTION
Forgot to push a news post for flux-framework.github.io after the tag of v0.7.0. This was created with the following script, from a checkout of the `v0.7.0` tag:


```bash
URL="https://github.com/flux-framework/flux-core/issues/"
TAG=$(git describe)
VERSION=$(git describe | sed 's/^v//')
AUTHOR="flux-framework"
COMMIT=$(git rev-parse $TAG)
DATE=$( git cat-file -p $COMMIT \
      | gawk '/^tagger/{print strftime ("%F %H:%M:%S %z", $(NF-1))}')

# Front matter
cat <<EOF
---
layout: news_item
title: "flux-core v$VERSION Released"
date: "$DATE"
author: "$AUTHOR"
categories: release
version: $VERSION
---

# flux-core v$VERSION Released

<div class="note warning">
This is an alpha release of flux-core and is not intended for production use.
</div>

Download from GitHub [here](https://github.com/flux-framework/flux-core/releases/tag/$TAG)

## Release Notes
EOF
# Get top list of Release Notes for a single version
#   replace Issue #'s with links
#
awk '/^flux-core version/{n++;getline;getline}; n<=1;' NEWS.md | \
 sed "s|#\([0-9][0-9]*\)|[#\1](${URL}\1)|g"


```