### PR TITLE
Add news entries for latest flux-core and flux-sched releases

### DIFF
--- a/_posts/2019-01-04-flux-core-0.11.0-released.md
+++ b/_posts/2019-01-04-flux-core-0.11.0-released.md
@@ -1,0 +1,82 @@
+---
+layout: news_item
+title: "flux-core v0.11.0 Released"
+date: "2019-01-04 20:37:44 +0000"
+author: "flux-framework"
+categories: release
+version: 0.11.0
+---
+
+# flux-core v0.11.0 Released
+
+<div class="note warning">
+This is an alpha release of flux-core and is not intended for production use.
+</div>
+
+Download from GitHub [here](https://github.com/flux-framework/flux-core/releases/tag/v0.11.0)
+
+## Release Notes
+
+### Fixes
+ * flux-module: increase width of size field in list output ([#1883](https://github.com/flux-framework/flux-core/issues/1883))
+ * kvs: return errors to callers on asynchronous load/store failures ([#1836](https://github.com/flux-framework/flux-core/issues/1836))
+ * flux-start: dispatch orphan brokers, fully clean up temp directories ([#1835](https://github.com/flux-framework/flux-core/issues/1835))
+ * flux-exec: ensure stdin is restored to blocking mode on exit ([#1814](https://github.com/flux-framework/flux-core/issues/1814))
+ * broker: do not connect to enclosing instance ([#1798](https://github.com/flux-framework/flux-core/issues/1798))
+ * flux (command): handle inaccessible build directory, fix PATH issue ([#1683](https://github.com/flux-framework/flux-core/issues/1683))
+ * wreck: fix incorrect error handling in job module ([#1617](https://github.com/flux-framework/flux-core/issues/1617))
+ * libflux: improve efficiency of asynchronous futures ([#1840](https://github.com/flux-framework/flux-core/issues/1840))
+ * libflux: fix composite future implementation ([#1791](https://github.com/flux-framework/flux-core/issues/1791))
+ * libflux: improve lookup efficiency of RPC message handlers ([#1807](https://github.com/flux-framework/flux-core/issues/1807))
+ * libflux: give all aux set/get interfaces uniform semantics ([#1797](https://github.com/flux-framework/flux-core/issues/1797))
+ * update to libev 4.25, ensure valgrind runs clean on i686 ([#1898](https://github.com/flux-framework/flux-core/issues/1898))
+
+### New Features
+ * license: re-publish project under LGPLv3 ([#1829](https://github.com/flux-framework/flux-core/issues/1829), [#1788](https://github.com/flux-framework/flux-core/issues/1788), [#1901](https://github.com/flux-framework/flux-core/issues/1901))
+ * wreck: use direct stdio transport, unless -okz option ([#1875](https://github.com/flux-framework/flux-core/issues/1875), [#1896](https://github.com/flux-framework/flux-core/issues/1896), [#1900](https://github.com/flux-framework/flux-core/issues/1900))
+ * wreck: add new -J, --name=JOBNAME option to flux-wreckrun and submit ([#1893](https://github.com/flux-framework/flux-core/issues/1893))
+ * libflux: support queue of future fulfillments ([#1610](https://github.com/flux-framework/flux-core/issues/1610))
+ * libflux: support dynamic service registration ([#1753](https://github.com/flux-framework/flux-core/issues/1753), [#1856](https://github.com/flux-framework/flux-core/issues/1856))
+ * kvs: replace inefficient KVS watch implementation and outdated API ([#1891](https://github.com/flux-framework/flux-core/issues/1891),
+   [#1890](https://github.com/flux-framework/flux-core/issues/1890), [#1882](https://github.com/flux-framework/flux-core/issues/1882), [#1878](https://github.com/flux-framework/flux-core/issues/1878), [#1879](https://github.com/flux-framework/flux-core/issues/1879), [#1873](https://github.com/flux-framework/flux-core/issues/1873), [#1870](https://github.com/flux-framework/flux-core/issues/1870), [#1868](https://github.com/flux-framework/flux-core/issues/1868), [#1863](https://github.com/flux-framework/flux-core/issues/1863),
+   [#1861](https://github.com/flux-framework/flux-core/issues/1861), [#1859](https://github.com/flux-framework/flux-core/issues/1859), [#1850](https://github.com/flux-framework/flux-core/issues/1850), [#1848](https://github.com/flux-framework/flux-core/issues/1848), [#1820](https://github.com/flux-framework/flux-core/issues/1820), [#1643](https://github.com/flux-framework/flux-core/issues/1643), [#1622](https://github.com/flux-framework/flux-core/issues/1622))
+ * job: add job-ingest, job-manager modules, and API (experimental)
+   ([#1867](https://github.com/flux-framework/flux-core/issues/1867), [#1774](https://github.com/flux-framework/flux-core/issues/1774), [#1734](https://github.com/flux-framework/flux-core/issues/1734), [#1626](https://github.com/flux-framework/flux-core/issues/1626))
+ * libidset: expand API to replace internal nodeset class ([#1862](https://github.com/flux-framework/flux-core/issues/1862))
+ * libflux: add KVS copy and move composite functions ([#1828](https://github.com/flux-framework/flux-core/issues/1828))
+ * libflux: access broker, library, command versions ([#1817](https://github.com/flux-framework/flux-core/issues/1817))
+ * kvs: restart with existing content sqlite, root reference ([#1800](https://github.com/flux-framework/flux-core/issues/1800), [#1812](https://github.com/flux-framework/flux-core/issues/1812))
+ * python: add job & mrpc bindings ([#1757](https://github.com/flux-framework/flux-core/issues/1757), [#1892](https://github.com/flux-framework/flux-core/issues/1892))
+ * python: add flux python command to run configured python ([#1766](https://github.com/flux-framework/flux-core/issues/1766))
+ * python: add flux-security bindings ([#1716](https://github.com/flux-framework/flux-core/issues/1716))
+ * python: Python3 compatibility ([#1673](https://github.com/flux-framework/flux-core/issues/1673))
+ * kvs: add RFC 18 eventlog support ([#1671](https://github.com/flux-framework/flux-core/issues/1671))
+ * libsubprocess: cleanup and redesign
+   ([#1713](https://github.com/flux-framework/flux-core/issues/1713), [#1664](https://github.com/flux-framework/flux-core/issues/1664), [#1659](https://github.com/flux-framework/flux-core/issues/1659), [#1658](https://github.com/flux-framework/flux-core/issues/1658), [#1654](https://github.com/flux-framework/flux-core/issues/1654), [#1645](https://github.com/flux-framework/flux-core/issues/1645), [#1636](https://github.com/flux-framework/flux-core/issues/1636), [#1629](https://github.com/flux-framework/flux-core/issues/1629))
+ * libflux/buffer: Add trimmed peek/read line variants ([#1639](https://github.com/flux-framework/flux-core/issues/1639))
+ * build: add library versioning support ([#1874](https://github.com/flux-framework/flux-core/issues/1874))
+ * build: add support for asciidoctor as manpage generator ([#1650](https://github.com/flux-framework/flux-core/issues/1650), [#1676](https://github.com/flux-framework/flux-core/issues/1676))
+ * travis-ci: run tests under docker ([#1688](https://github.com/flux-framework/flux-core/issues/1688), [#1684](https://github.com/flux-framework/flux-core/issues/1684), [#1670](https://github.com/flux-framework/flux-core/issues/1670))
+
+### Cleanup
+ * libflux: drop broker zeromq security functions from public API ([#1846](https://github.com/flux-framework/flux-core/issues/1846))
+ * libflux: clean up interface for broker attributes ([#1845](https://github.com/flux-framework/flux-core/issues/1845))
+ * libflux: drop reduction code from public API ([#1844](https://github.com/flux-framework/flux-core/issues/1844))
+ * libutil: switch from munge to libsodium base64 implementation ([#1786](https://github.com/flux-framework/flux-core/issues/1786))
+ * python: python binding is no longer optional ([#1772](https://github.com/flux-framework/flux-core/issues/1772))
+ * python: add "black" format check, and reformat existing code ([#1802](https://github.com/flux-framework/flux-core/issues/1802))
+ * python/lua: avoid deprecated kvs functions ([#1748](https://github.com/flux-framework/flux-core/issues/1748))
+ * kvs: misc cleanup, refactoring, and fixes
+   ([#1805](https://github.com/flux-framework/flux-core/issues/1805), [#1813](https://github.com/flux-framework/flux-core/issues/1813), [#1773](https://github.com/flux-framework/flux-core/issues/1773), [#1764](https://github.com/flux-framework/flux-core/issues/1764), [#1712](https://github.com/flux-framework/flux-core/issues/1712), [#1696](https://github.com/flux-framework/flux-core/issues/1696), [#1694](https://github.com/flux-framework/flux-core/issues/1694))
+ * broker: drop epgm event distribution (and munge dependency) ([#1746](https://github.com/flux-framework/flux-core/issues/1746))
+ * content-sqlite: switch from lzo to lz4 ([#1740](https://github.com/flux-framework/flux-core/issues/1740))
+ * libpmi: drop PMIx client support ([#1663](https://github.com/flux-framework/flux-core/issues/1663))
+ * libpmi: avoid synchronous RPCs in simple-server kvs ([#1615](https://github.com/flux-framework/flux-core/issues/1615))
+ * modules/cron: misc cleanup ([#1657](https://github.com/flux-framework/flux-core/issues/1657))
+ * RFC 7: fix various style violations ([#1705](https://github.com/flux-framework/flux-core/issues/1705), [#1717](https://github.com/flux-framework/flux-core/issues/1717), [#1706](https://github.com/flux-framework/flux-core/issues/1706), [#1611](https://github.com/flux-framework/flux-core/issues/1611))
+ * gcc8: fix output truncation ([#1642](https://github.com/flux-framework/flux-core/issues/1642))
+ * sanitizer: fix memory leaks ([#1737](https://github.com/flux-framework/flux-core/issues/1737), [#1736](https://github.com/flux-framework/flux-core/issues/1736), [#1739](https://github.com/flux-framework/flux-core/issues/1739), [#1737](https://github.com/flux-framework/flux-core/issues/1737), [#1735](https://github.com/flux-framework/flux-core/issues/1735), [#1733](https://github.com/flux-framework/flux-core/issues/1733))
+ * build: misc. cleanup and fixes ([#1886](https://github.com/flux-framework/flux-core/issues/1886), [#1795](https://github.com/flux-framework/flux-core/issues/1795), [#1824](https://github.com/flux-framework/flux-core/issues/1824), [#1827](https://github.com/flux-framework/flux-core/issues/1827), [#1701](https://github.com/flux-framework/flux-core/issues/1701), [#1678](https://github.com/flux-framework/flux-core/issues/1678))
+ * test: misc. cleanup and fixes ([#1644](https://github.com/flux-framework/flux-core/issues/1644), [#1704](https://github.com/flux-framework/flux-core/issues/1704), [#1691](https://github.com/flux-framework/flux-core/issues/1691), 1640)
+
+

--- a/_posts/2019-01-22-flux-sched-v0.7.0-released.md
+++ b/_posts/2019-01-22-flux-sched-v0.7.0-released.md
@@ -1,0 +1,50 @@
+---
+layout: news_item
+title: "flux-sched v0.7.0 Released"
+date: "2019-01-22 21:24:04 +0000"
+author: "flux-framework"
+categories: release
+version: 0.7.0
+---
+
+# flux-sched v0.7.0 Released
+
+<div class="note warning">
+This is an alpha release of flux-sched and is not intended for production use.
+</div>
+
+Download from GitHub [here](https://github.com/flux-framework/flux-sched/releases/tag/v0.7.0)
+
+## Release Notes
+
+### Fixes
+ * sched/plugin: track flux-core module API changes ([#414](https://github.com/flux-framework/flux-sched/issues/414))
+ * Ensure scheduling correctness with different prune filter configurations
+   ([#419](https://github.com/flux-framework/flux-sched/issues/419))
+ * travis: fix docker and github release deployment ([#424](https://github.com/flux-framework/flux-sched/issues/424))
+ * travis-ci: fix docker deploy better ([#426](https://github.com/flux-framework/flux-sched/issues/426))
+ * docker: update repo tag names, ensure flux-sched installed with
+   prefix=/usr ([#427](https://github.com/flux-framework/flux-sched/issues/427))
+ * docker: add yaml-cpp dependency ([#428](https://github.com/flux-framework/flux-sched/issues/428))
+ * config: Fix a non-portable use of shell conditionals for automake
+   ([#405](https://github.com/flux-framework/flux-sched/issues/405))
+ * config: Add libtoolize into autogen.sh ([#406](https://github.com/flux-framework/flux-sched/issues/406))
+ * Integrate jobspec into resource, etc ([#398](https://github.com/flux-framework/flux-sched/issues/398))
+ * Compilation fixes ([#417](https://github.com/flux-framework/flux-sched/issues/417))
+
+### Features
+ * travis-ci: use docker for test builds ([#392](https://github.com/flux-framework/flux-sched/issues/392))
+ * resource: support for hwloc ingestion ([#385](https://github.com/flux-framework/flux-sched/issues/385))
+ * Add support for resource matching service ([#386](https://github.com/flux-framework/flux-sched/issues/386))
+ * planner: Replace zhash_t to zhashx_t for higher performance ([#391](https://github.com/flux-framework/flux-sched/issues/391))
+ * resource: wire in --prune-filters option for resource-query and
+   matching module ([#401](https://github.com/flux-framework/flux-sched/issues/401))
+ * resource: Add run-level support for resource matching module ([#418](https://github.com/flux-framework/flux-sched/issues/418))
+ * Add better autoconf support for libboost ([#394](https://github.com/flux-framework/flux-sched/issues/394))
+
+### Cleanup
+ * build: do not install libflux-rdl.so, fix rebuild of aclocal.m4 on
+   first make ([#421](https://github.com/flux-framework/flux-sched/issues/421))
+ * sched: remove trailing whitespaces ([#376](https://github.com/flux-framework/flux-sched/issues/376))
+
+


### PR DESCRIPTION
I need to try to automate this process. I used the following script to autogenerate these posts for the site, perhaps this should be checked in somehwere:
```shell
#!/bin/sh
VERSION=$1
if test -z "$VERSION"; then
    echo "Usage: $0 VERSION [flux-core|flux-sched]" >&2
    exit 1
fi
NAME=${2:-flux-core}
WORKDIR=$(mktemp --directory ${TMPDIR:-/tmp}/${NAME}.XXXXXX)
echo "Cloning $NAME $VERSION into $WORKDIR" >&2
git clone --quiet --branch=v${VERSION} https://github.com/flux-framework/${NAME} ${WORKDIR}
cd ${WORKDIR}

URL="https://github.com/flux-framework/${NAME}/issues/"
TAG=$(git describe)
AUTHOR="flux-framework"
COMMIT=$(git rev-parse $TAG)
DATE=$( git cat-file -p $COMMIT \
      | gawk '/^tagger/{print strftime ("%F %H:%M:%S %z", $(NF-1))}')

# Front matter
cat <<EOF
---
layout: news_item
title: "${NAME} v$VERSION Released"
date: "$DATE"
author: "$AUTHOR"
categories: release
version: $VERSION
---

# ${NAME} v$VERSION Released

<div class="note warning">
This is an alpha release of ${NAME} and is not intended for production use.
</div>

Download from GitHub [here](https://github.com/flux-framework/${NAME}/releases/tag/$TAG)

## Release Notes
EOF
# Get top list of Release Notes for a single version
#   replace Issue #'s with links
#
awk "/^${NAME} version/{n++;getline;getline}; n<=1;" NEWS.md | \
 sed "s|#\([0-9][0-9]*\)|[#\1](${URL}\1)|g"

cd /tmp 
rm -rf ${WORKDIR}
```