### PR TITLE
analytics: add matomo analytics javascript

### DIFF
--- a/_includes/matomo.html
+++ b/_includes/matomo.html
@@ -1,0 +1,15 @@
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://analytics.llnl.gov/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '378']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->

--- a/_includes/top.html
+++ b/_includes/top.html
@@ -11,4 +11,7 @@
   <script src="/js/html5shiv.min.js"></script>
   <script src="/js/respond.min.js"></script>
   <![endif]-->
+   {% if jekyll.environment == 'production' %}
+   {% include matomo.html %}
+   {% endif %}
 </head>


### PR DESCRIPTION
Note: when running `jekyll serve`, the `jekyll.environment` is
    `development`.  The layout is configured to only include the matomo code
    when running in `production` environments to avoid pinging the analytics
    server unnecessarily during development.  To force the analytics code to
    be generated when running locally, use `JEKYLL_ENV=production jekyll
    build`.

Source: https://michaelsoolee.com/google-analytics-jekyll/