### PR TITLE
[WIP] flux-accounting: add dates, author to release notes

### DIFF
--- a/_posts/2020-07-29-flux-accounting-0.1.0.md
+++ b/_posts/2020-07-29-flux-accounting-0.1.0.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: "flux-accounting v0.1.0"
+date: "2020-07-29 10:00:00 -08:00"
+author: cmoussa1
+categories: release
+version: 0.1.0
+download: https://github.com/flux-framework/flux-accounting/releases/tag/
+---
+
+Download from GitHub [here](https://github.com/flux-framework/flux-accounting/releases/tag/)
+
+# Release Notes
+
+Initial release.
+
+#### Features
+
+* Create an accounting database which stores user account information. Can interact with database through SQLite shell or
+through a command line interface to add and remove users, edit account values, and view account information.
+
+* Add **Makefile** to allow flux-accounting to be installed alongside flux-core so that flux-accounting commands can be picked up by Flux's command driver.

--- a/_posts/2020-09-08-flux-accounting-0.2.0.md
+++ b/_posts/2020-09-08-flux-accounting-0.2.0.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: "flux-accounting v0.2.0"
+date: "2020-09-08 10:00:00 -08:00"
+author: cmoussa1
+categories: release
+version: 0.2.0
+download: https://github.com/flux-framework/flux-accounting/releases/tag/
+---
+
+Download from GitHub [here](https://github.com/flux-framework/flux-accounting/releases/tag/)
+
+# Release Notes
+
+This release adds a new table to the flux-accounting database and a front end to flux-core's job-archive.
+
+#### Features
+
+* Add a new table `bank_table` that stores bank information for users to charge jobs against.
+
+* Add a front-end interface to flux-core's job-archive to fetch job record information and sort it with customizable parameters, such as by username, before or after a specific time, or with a specific job ID.
+

--- a/_posts/2020-10-06-flux-accounting-0.3.0.md
+++ b/_posts/2020-10-06-flux-accounting-0.3.0.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: "flux-accounting v0.3.0"
+date: "2020-10-06 10:00:00 -08:00"
+author: cmoussa1
+categories: release
+version: 0.3.0
+download: https://github.com/flux-framework/flux-accounting/releases/tag/
+---
+
+Download from GitHub [here](https://github.com/flux-framework/flux-accounting/releases/tag/)
+
+# Release Notes
+
+#### Fixes
+
+* `bank_table`'s primary key is now a fixed type ([#42](https://github.com/flux-framework/flux-accounting/issues/42))
+
+* `bank_table`'s subcommands no longer impose constraints on values of shares ([#44](https://github.com/flux-framework/flux-accounting/issues/44))
+
+* `print-hierarchy`'s format improved to represent a bank and user hierarchy ([#51](https://github.com/flux-framework/flux-accounting/issues/51))
+

--- a/_posts/2020-11-09-flux-accounting-0.4.0.md
+++ b/_posts/2020-11-09-flux-accounting-0.4.0.md
@@ -1,0 +1,26 @@
+---
+layout: default
+title: "flux-accounting v0.4.0"
+date: "2020-11-09 10:00:00 -08:00"
+author: cmoussa1
+categories: release
+version: 0.4.0
+download: https://github.com/flux-framework/flux-accounting/releases/tag/
+---
+
+Download from GitHub [here](https://github.com/flux-framework/flux-accounting/releases/tag/)
+
+# Release Notes
+
+#### Fixes
+
+* `view-job-records` subcommand parameters adjusted to be unpacked as a dictionary ([#55](https://github.com/flux-framework/flux-accounting/issues/55))
+
+* Move `view_job_records()` and its helper functions into its own Python module ([#57](https://github.com/flux-framework/flux-accounting/issues/57))
+
+#### Features
+
+* Add a library that provides a weighted tree-based fairness ([#65](https://github.com/flux-framework/flux-accounting/issues/65))
+
+* Add autogen, automake tools to flux-accounting repo ([#65](https://github.com/flux-framework/flux-accounting/issues/65))
+

--- a/_posts/2020-12-18-flux-accounting-0.5.0.md
+++ b/_posts/2020-12-18-flux-accounting-0.5.0.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: "flux-accounting v0.5.0"
+date: "2020-12-18 10:00:00 -08:00"
+author: cmoussa1
+categories: release
+version: 0.5.0
+download: https://github.com/flux-framework/flux-accounting/releases/tag/
+---
+
+Download from GitHub [here](https://github.com/flux-framework/flux-accounting/releases/tag/)
+
+# Release Notes
+
+#### Fixes
+
+* `print-hierarchy`'s error output more graceful when there are no accounts ([#62](https://github.com/flux-framework/flux-accounting/issues/62))
+
+* `association_table`'s `user_name` field changed to `username` ([#67](https://github.com/flux-framework/flux-accounting/issues/67))
+
+* **accounting_cli.py**'s `account` option changed to `bank` ([#70](https://github.com/flux-framework/flux-accounting/issues/70))
+
+* variables in **print_hierarchy.cpp** moved from `global` scope ([#71](https://github.com/flux-framework/flux-accounting/issues/71))
+
+* Python code converted over to use autotools, TAP, and sharness ([#73](https://github.com/flux-framework/flux-accounting/issues/73))
+
+#### Features
+
+* `print-hierarchy` added as a C++ implementation to weighted tree lib ([#64](https://github.com/flux-framework/flux-accounting/issues/64))
+
+* `delete-bank` recursively deletes sub banks and associations when a parent bank is deleted ([#78](https://github.com/flux-framework/flux-accounting/issues/78))
+
+* `calc_usage_factor()` calculates a user's historical job usage value based on their job history ([#79](https://github.com/flux-framework/flux-accounting/issues/79))
+

--- a/_posts/2021-02-19-flux-accounting-0.6.0.md
+++ b/_posts/2021-02-19-flux-accounting-0.6.0.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: "flux-accounting v0.6.0"
+date: "2021-02-19 10:00:00 -08:00"
+author: cmoussa1
+categories: release
+version: 0.6.0
+download: https://github.com/flux-framework/flux-accounting/releases/tag/
+---
+
+Download from GitHub [here](https://github.com/flux-framework/flux-accounting/releases/tag/)
+
+# Release Notes
+
+#### Fixes
+
+* Unused variables and imports removed, license in `src/fairness/` changed to LGPL ([#90](https://github.com/flux-framework/flux-accounting/issues/90))
+
+* Behavior of `delete-user`, `delete-bank` changed to keep job history of a user after they are removed from the flux-accounting DB ([#92](https://github.com/flux-framework/flux-accounting/issues/92))
+
+* `bank` argument added to the `delete-user` subcommand ([#95](https://github.com/flux-framework/flux-accounting/issues/95))
+
+#### Features
+
+* `unittest.mock()` integrated with job-archive interface unit tests ([#93](https://github.com/flux-framework/flux-accounting/issues/93))
+
+* flux-accounting database can be loaded into weighted tree library to generate fairshare values for users ([#97](https://github.com/flux-framework/flux-accounting/issues/97))
+

--- a/_posts/2021-04-02-flux-accounting-0.7.0.md
+++ b/_posts/2021-04-02-flux-accounting-0.7.0.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: "flux-accounting v0.7.0"
+date: "2021-04-02 10:00:00 -08:00"
+author: cmoussa1
+categories: release
+version: 0.7.0
+download: https://github.com/flux-framework/flux-accounting/releases/tag/
+---
+
+Download from GitHub [here](https://github.com/flux-framework/flux-accounting/releases/tag/)
+
+# Release Notes
+
+#### Fixes
+
+* Fixed `ModuleNotFound` error when running Python unit tests on Python `3.6` ([#106](https://github.com/flux-framework/flux-accounting/issues/106))
+
+* Removed shebang line from **flux-account.py** to prevent Python version mismatch errors ([#101](https://github.com/flux-framework/flux-accounting/issues/101))
+
+#### Features
+
+* Added a new `reader` class which will read flux-accounting information and load it to a `weighted_tree` object ([#103](https://github.com/flux-framework/flux-accounting/issues/103))
+
+    * Added a subclass `data_reader_db` which will read and load information from a flux-accounting SQLite database
+
+* Added a new flux subcommand: `flux shares`, which will output a flux-accounting database hierarchy containing user/bank shares and usage information ([#109](https://github.com/flux-framework/flux-accounting/issues/109))
+

--- a/_posts/2021-04-27-flux-accounting-0.8.0.md
+++ b/_posts/2021-04-27-flux-accounting-0.8.0.md
@@ -1,0 +1,38 @@
+---
+layout: default
+title: "flux-accounting v0.8.0"
+date: "2021-04-27 15:11:27 -0700"
+author: cmoussa1
+categories: release
+version: 0.8.0
+download: https://github.com/flux-framework/flux-accounting/releases/tag/v0.8.0
+---
+
+Download from GitHub [here](https://github.com/flux-framework/flux-accounting/releases/tag/v0.8.0)
+
+# Release Notes
+
+#### Fixes
+
+* Updated headers of source files in the `fairness` directory ([#113](https://github.com/flux-framework/flux-accounting/issues/113))
+
+* Fixed module/dependency installation strategy of flux-accounting on the `bionic` Docker image ([#114](https://github.com/flux-framework/flux-accounting/issues/114))
+
+* Fixed bug where old job usage values incorrectly included old factors when applying a decay value ([#118](https://github.com/flux-framework/flux-accounting/issues/118))
+
+* Fixed bug where the all job usage factors were incorrectly updated multiple times in one half-life period ([#118](https://github.com/flux-framework/flux-accounting/issues/118))
+
+* Fixed bug where a historical job usage value was updated even in the case where no new jobs were found in the current half-life period ([#118](https://github.com/flux-framework/flux-accounting/issues/118))
+
+* Fixed bug where the last seen job timestamp was reset to 0 if no new jobs were found for a user ([#118](https://github.com/flux-framework/flux-accounting/issues/118))
+
+#### Features
+
+* Added a new `fairshare` field to the `association_table` in a flux-accounting database ([#116](https://github.com/flux-framework/flux-accounting/issues/116))
+
+* Added a new `writer` class which will update associations with up-to-date fairshare information ([#116](https://github.com/flux-framework/flux-accounting/issues/116))
+
+    * Added a subclass `data_writer_db` which will write fairshare information to a flux-accounting SQLite database
+
+* Added a new subcommand to `flux account` that calculates and updates historical job usage values for every association in the flux-accounting database ([#118](https://github.com/flux-framework/flux-accounting/issues/118))
+


### PR DESCRIPTION
#### Problem

Releases for flux-accounting `v0.1.0`-`0.7.0` did not use annotated tags for their respective releases, resulting in some partly incorrect markdown documents with missing dates and author names.

#### Solution

Manually add the dates and author fields for releases `v0.1.0-0.7.0`.

Fixes #47