### PR TITLE
layouts: add twitter & change copyright to default

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,6 +30,7 @@
             <a href="{{ site.url | prepend: site.baseurl }}/releases/" class="btn"><i class="fa fa-code-fork"></i> Releases</a>
             <a href="https://flux-framework.readthedocs.io/en/latest/contributing.html" class="btn" target="_blank"><i class="fa fa-plus"></i> Contribute</a>
             <a href="mailto:flux-discuss@lists.llnl.gov" class="btn"><i class="fa fa-envelope-o"></i> Contact</a>
+            <a href="https://twitter.com/fluxframework" class="btn"><i class="fa fa-twitter"></i> Twitter</a>
         </section>
     </header>
 
@@ -42,7 +43,7 @@
       {{ content }}
 
       <footer class="site-footer">
-        <span class="site-footer-owner">The contents of this website are ©2020 <a href="http://github.com/flux-framework">Flux Framework Community</a> under the terms of the <a href="https://github.com/flux-framework/rfc/blob/master/spec_2.adoc">LGPL License</a>.</span>
+        <span class="site-footer-owner">The contents of this website are ©2021 <a href="http://github.com/flux-framework">Flux Framework Community</a> under the terms of the <a href="https://github.com/flux-framework/rfc/blob/master/spec_2.adoc">LGPL License</a>.</span>
       </footer>
     </main>
   </body>


### PR DESCRIPTION
Updated default.html in two ways:

1. Add button for Twitter icon/link in site header (I put it at the end of the row of buttons but can move it if desired) 
2. Update 2020 to 2021 in copyright statement in site footer