### PR TITLE
add update release action

### DIFF
--- a/.github/workflows/update-releases.yaml
+++ b/.github/workflows/update-releases.yaml
@@ -1,0 +1,22 @@
+name: Update Docs
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 23 2 * * *
+
+jobs:
+  update-release-docs:
+    name: Generate posts for Flux projects
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Flux projects update
+        uses: rse-ops/release-actions/docs@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          author: flux-framework
+          layout: default
+          start_at: 2022
+          branch: master

--- a/contributor-ci.yaml
+++ b/contributor-ci.yaml
@@ -1,0 +1,21 @@
+# Note this isn't currently used in this context
+outdir: _data/cci
+
+# These two are only required to group people into member groups,
+# which we don't really need or want to do.
+orgs: []
+member_orgs: []
+
+# Custom set of repos in radiuss
+repos:
+- flux-framework/flux-core
+- flux-framework/flux-sched
+- flux-framework/flux-accounting
+- flux-framework/flux-pmix
+
+# Parsing functions to use (e.g, parse a NEWS.md)
+functions:
+  flux-framework/flux-core: linked-news-markdown-rst
+  flux-framework/flux-sched: linked-news-markdown-rst
+  flux-framework/flux-accounting: linked-news-markdown-rst
+  flux-framework/flux-pmix: linked-news-markdown-rst


### PR DESCRIPTION
This will run nightly to look for new Flux Framework org projects (a named subset) and if found, write to a new release file, a markdown post. Since we are testing and I am not sure about a start at date (can go up to granularity of a year, month, day) I have dry run set to true. I'll update the description when it appears to be working and discussion is needed!

- Action repository: https://github.com/rse-ops/release-actions/tree/main/docs
- See TBA new additions (click on star arrows) under "Flux projects update" here https://github.com/flux-framework/flux-framework.github.io/actions/runs/3710652493/jobs/6290339684

Signed-off-by: vsoch <vsoch@users.noreply.github.com>