### PR TITLE
Updating flux security parser

### DIFF
--- a/contributor-ci.yaml
+++ b/contributor-ci.yaml
@@ -22,3 +22,4 @@ functions:
   flux-framework/flux-sched: linked-news-markdown-rst
   flux-framework/flux-accounting: linked-news-markdown-rst
   flux-framework/flux-pmix: linked-news-markdown-rst
+  flux-framework/flux-security: linked-news-markdown-rst


### PR DESCRIPTION
Flux security is not known to need special parsing, so it is just including the release body. This PR will ask it to be parsed akin to the others to see the full changeset.