### PR TITLE
Minor changes to home & nav

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -28,9 +28,9 @@
         <a href="{{ site.baseurl }}/api/"><i class="fa fa-code"></i> APIs</a>
       </li>
       <li class="community">
-        <a href="mailto:flux-discuss@lists.llnl.gov" target="_blank">Contact <i style="font-size:12px;margin-left:2px;" class="fa fa-envelope-o"></i></a>
+        <a href="mailto:flux-discuss@lists.llnl.gov" target="_blank"><i class="fa-solid fa-envelope"></i> Contact</i></a>
       </li>
-      <li><a href="https://github.com/flux-framework/" target="_blank">GitHub <i style="font-size:12px;margin-left:2px;" class="fa fa-external-link"></i></a></li>
+      <li><a href="https://github.com/flux-framework/" target="_blank"><i class="fa-brands fa-github"></i> GitHub</a></li>
       </li> 
     </ul>
   </nav>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -236,8 +236,9 @@ footer {
   /*Simple css to style it like a toggle switch*/
   .theme-switch-wrapper {
     display: flex;
-    align-items: center;
-    padding-top:20px;
+    align-items: left;
+    padding-top: 20px;
+    padding-left: 100px;
 
     em {
       margin-left: 10px;

--- a/pages/index.md
+++ b/pages/index.md
@@ -13,7 +13,7 @@ hide_hero: true
  <img src="{{ site.baseurl }}/assets/images/Flux-logo-full.png" class="flux-logo">
 <h2 class='flux-tagline'>{{ site.tagline }}</h2>
     <input name="tags" style="width:600px; margin:auto;margin-bottom:30px">
-    <p class="flux-tagline-small">Looking for a particular project? Try entering a language or term you're interested in, like "python" or "security" above.</p>
+    <p class="flux-tagline-small">Looking for a particular project? Try entering a language or term you're interested in, like <em>python</em> or <em>security</em> above.</p>
   </div>
 
 <p style="text-align:center; margin:auto"><button id='star-sort' class="btn">Sort by ⭐️</button><button id='language-sort' style="margin-left:10px" class="btn">Sort by Language</button><button id='name-sort' style="margin-left:10px" class="btn">Sort by Name</button></p>


### PR DESCRIPTION
- Add envelope and GitHub icons to nav bar
- Move dark mode toggle closer to the Flux logo in header (just to the right of it)
- Italicize two words in the home page tagline